### PR TITLE
allow not creating/managing the S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,15 @@ Terraform module for deploying and managing a CloudFront web distribution backed
 
 * Note if you do not want Route 53 records created pointing to the cloudfront distribution you can optionally not pass in cloudfront_fqdn. In this case you must specify cloudfront_aliases.
 
+* Note if you do not want to create/manage the S3 bucket (such as for the use case of having multiple CloudFront distributions sourced from different paths of the same S3 bucket), pass `create_bucket = false` (see below for details).
+
 #### Optional
 
 ```
 Optional value                                            Default
 
+- create_bucket                                           true
+- cloudfront_origin_access_identity_path                  ""
 - iam_policy_resources_path                               "/*"
 - bucket_acl                                              "private"
 - bucket_force_destroy                                    false
@@ -56,7 +60,7 @@ Usage
 ```hcl
 
 module "static_web" {
-  source                            = "github.com/FitnessKeeper/terraform-aws-s3-cloudfront?ref=v0.0.3"
+  source                            = "github.com/FitnessKeeper/terraform-aws-s3-cloudfront?ref=v0.0.4"
   bucket_name                       = "static-bucket-mydomain"
   s3_region                         = "${data.aws_region.current.name}"
   cloudfront_fqdn                   = "static.mydomain.com"
@@ -65,9 +69,41 @@ module "static_web" {
 }
 ```
 
+* Note if you do not want to create/manage the S3 bucket (such as for the use case of having multiple CloudFront distributions sourced from different paths of the same S3 bucket), set `create_bucket = false`. You will then need to pass in the `cloudfront_origin_access_identity_path` to the one created when you set up your S3 bucket (all CloudFronts pointing to this bucket must use same CloudFront Origin Access Identity). You should also setup CORS on the S3 bucket to allow all of the domains for the additional CloudFront distributions.
+
+```hcl
+
+module "static_main" {
+  source                            = "github.com/FitnessKeeper/terraform-aws-s3-cloudfront?ref=v0.0.4"
+  bucket_name                       = "static-bucket-mydomain"
+  cloudfront_origin_path            = "/static_main"
+  bucket_cors_extra_allowed_origins = ["*.mydomain.com"]
+  s3_region                         = "${data.aws_region.current.name}"
+  cloudfront_fqdn                   = "static.mydomain.com"
+  cloudfront_acm_cert_domain        = "mydomain.com"
+  route53_toplevel_domain           = "mydomain.com"
+}
+
+module "static2" {
+  source                                 = "github.com/FitnessKeeper/terraform-aws-s3-cloudfront?ref=v0.0.4"
+  bucket_name                            = "static-bucket-mydomain"
+  cloudfront_origin_path                 = "/static2"
+  create_bucket                          = false
+  cloudfront_origin_access_identity_path = "${module.static_main.cloudfront_origin_access_identity_path}"
+  s3_region                              = "${data.aws_region.current.name}"
+  cloudfront_fqdn                        = "static2.mydomain.com"
+  cloudfront_acm_cert_domain             = "mydomain.com"
+  route53_toplevel_domain                = "mydomain.com"
+}
+
+```
+
+
+
 Outputs
 =======
 
+- cloudfront_origin_access_identity_path
 - cloudfront_domain_name
 - cloudfront_zone_id
 
@@ -80,6 +116,7 @@ Changelog
 =========
 
 0.0.1 - Initial version.
+0.0.4 - Allow not creating/managing the S3 bucket.
 
 License
 =======

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Terraform module for deploying and managing a CloudFront web distribution backed
 
 * Note if you do not want to create/manage the S3 bucket (such as for the use case of having multiple CloudFront distributions sourced from different paths of the same S3 bucket), pass `create_bucket = false` (see below for details).
 
+* Note if you do not want this module to create a CloudFront Origin Access Identity, you must pass in `cloudfront_origin_access_identity_path`. If you do still want it to create the S3 bucket, you must also pass in `cloudfront_origin_access_identity_iam_arn` (there is no Terraform AWS provider data source for CloudFront Origin Access Identity, so these can't be looked up).
+
+* Note, if you do not want this module to create the S3 bucket, but you do want it to create the CloudFront Origin Access Identity, it will output `cloudfront_origin_access_identity_path` and `cloudfront_origin_access_identity_iam_arn` so that you can add them to the bucket policy manually.
+
 #### Optional
 
 ```
@@ -25,6 +29,7 @@ Optional value                                            Default
 
 - create_bucket                                           true
 - cloudfront_origin_access_identity_path                  ""
+- cloudfront_origin_access_identity_iam_arn               ""
 - iam_policy_resources_path                               "/*"
 - bucket_acl                                              "private"
 - bucket_force_destroy                                    false
@@ -98,12 +103,11 @@ module "static2" {
 
 ```
 
-
-
 Outputs
 =======
 
 - cloudfront_origin_access_identity_path
+- cloudfront_origin_access_identity_iam_arn
 - cloudfront_domain_name
 - cloudfront_zone_id
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Terraform module for deploying and managing a CloudFront web distribution backed
 - route53_toplevel_zone      (existing top-level DNS domain for the Route53 record)
 ```
 
-* Note if you do not want Route 53 records created pointing to the cloudfront distribution you can optionally not pass in cloudfront_fqdn. In this case you must specify cloudfront_aliases.
+* Note if you do not want Route 53 records created pointing to the CloudFront distribution you can optionally not pass in `cloudfront_fqdn`. In this case you must specify `cloudfront_aliases` and ensure that the domain to be used for this CloudFront Distribution is allowed in the bucket CORS allowed origins (`bucket_cors_extra_allowed_origins`).
 
 * Note if you do not want to create/manage the S3 bucket (such as for the use case of having multiple CloudFront distributions sourced from different paths of the same S3 bucket), pass `create_bucket = false` (see below for details).
 
@@ -69,7 +69,7 @@ module "static_web" {
 }
 ```
 
-* Note if you do not want to create/manage the S3 bucket (such as for the use case of having multiple CloudFront distributions sourced from different paths of the same S3 bucket), set `create_bucket = false`. You will then need to pass in the `cloudfront_origin_access_identity_path` to the one created when you set up your S3 bucket (all CloudFronts pointing to this bucket must use same CloudFront Origin Access Identity). You should also setup CORS on the S3 bucket to allow all of the domains for the additional CloudFront distributions.
+* Note if you do not want to create/manage the S3 bucket (such as for the use case of having multiple CloudFront distributions sourced from different paths of the same S3 bucket), set `create_bucket = false`. You will then need to pass in the `cloudfront_origin_access_identity_path` to the one created when you set up your S3 bucket (all CloudFront distributions pointing to this bucket must use same CloudFront Origin Access Identity). You should also setup CORS on the S3 bucket to allow all of the domains for the additional CloudFront distributions.
 
 ```hcl
 
@@ -115,8 +115,8 @@ Authors
 Changelog
 =========
 
-0.0.1 - Initial version.
-0.0.4 - Allow not creating/managing the S3 bucket.
+- 0.0.1 - Initial version.
+- 0.0.4 - Allow not creating/managing the S3 bucket.
 
 License
 =======

--- a/data.tf
+++ b/data.tf
@@ -1,6 +1,13 @@
 # Data tier - S3
 
+
+resource "aws_cloudfront_origin_access_identity" "identity" {
+  count = "${var.create_bucket ? 1 : 0}"
+  comment = "CloudFront access to S3 bucket ${var.bucket_name}"
+}
+
 data "aws_iam_policy_document" "bucket_policy_document" {
+  count = "${var.create_bucket ? 1 : 0}"
   statement {
     sid       = "1"
     actions   = ["s3:GetObject"]
@@ -25,6 +32,7 @@ data "aws_iam_policy_document" "bucket_policy_document" {
 }
 
 resource "aws_s3_bucket" "bucket" {
+  count = "${var.create_bucket ? 1 : 0}"
   provider      = "aws.s3"
   bucket        = "${var.bucket_name}"
   acl           = "${var.bucket_acl}"
@@ -43,3 +51,7 @@ resource "aws_s3_bucket" "bucket" {
 
 
 # outputs from data tier
+
+output "cloudfront_origin_access_identity_path" {
+  value = "${aws_cloudfront_origin_access_identity.identity.cloudfront_access_identity_path}"
+}

--- a/data.tf
+++ b/data.tf
@@ -2,7 +2,7 @@
 
 
 resource "aws_cloudfront_origin_access_identity" "identity" {
-  count = "${var.create_bucket ? 1 : 0}"
+  count = "${(var.cloudfront_origin_access_identity_path == "") ? 1 : 0}"
   comment = "CloudFront access to S3 bucket ${var.bucket_name}"
 }
 
@@ -15,7 +15,7 @@ data "aws_iam_policy_document" "bucket_policy_document" {
 
     principals {
       type        = "AWS"
-      identifiers = ["${aws_cloudfront_origin_access_identity.identity.iam_arn}"]
+      identifiers = ["${(var.cloudfront_origin_access_identity_path == "") ? aws_cloudfront_origin_access_identity.identity.iam_arn : var.cloudfront_origin_access_identity_iam_arn}"]
     }
   }
 
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "bucket_policy_document" {
 
     principals {
       type        = "AWS"
-      identifiers = ["${aws_cloudfront_origin_access_identity.identity.iam_arn}"]
+      identifiers = ["${(var.cloudfront_origin_access_identity_path == "") ? aws_cloudfront_origin_access_identity.identity.iam_arn : var.cloudfront_origin_access_identity_iam_arn}"]
     }
   }
 }
@@ -51,6 +51,10 @@ resource "aws_s3_bucket" "bucket" {
 
 
 # outputs from data tier
+
+output "cloudfront_origin_access_identity_iam_arn" {
+  value = "${aws_cloudfront_origin_access_identity.identity.iam_arn}"
+}
 
 output "cloudfront_origin_access_identity_path" {
   value = "${aws_cloudfront_origin_access_identity.identity.cloudfront_access_identity_path}"

--- a/edge.tf
+++ b/edge.tf
@@ -34,7 +34,7 @@ resource "aws_cloudfront_distribution" "cloudfront" {
     origin_path = "${var.cloudfront_origin_path}"
 
     s3_origin_config {
-      origin_access_identity = "${var.create_bucket ? join("", aws_cloudfront_origin_access_identity.identity.*.cloudfront_access_identity_path) : var.cloudfront_origin_access_identity_path}"
+      origin_access_identity = "${(var.cloudfront_origin_access_identity_path == "") ? join("", aws_cloudfront_origin_access_identity.identity.*.cloudfront_access_identity_path) : var.cloudfront_origin_access_identity_path}"
     }
   }
 

--- a/edge.tf
+++ b/edge.tf
@@ -26,18 +26,15 @@ resource "aws_route53_record" "cloudfront_aaaa" {
   }
 }
 
-resource "aws_cloudfront_origin_access_identity" "identity" {
-  comment = "CloudFront access to S3 bucket ${var.bucket_name}"
-}
 
 resource "aws_cloudfront_distribution" "cloudfront" {
   origin {
-    domain_name = "${aws_s3_bucket.bucket.bucket_domain_name}"
-    origin_id   = "${aws_s3_bucket.bucket.id}"
+    domain_name = "${(var.create_bucket) ? join("", aws_s3_bucket.bucket.*.bucket_domain_name) : local.bucket_domain_name}"
+    origin_id   = "${var.create_bucket ? join("", aws_s3_bucket.bucket.*.id) : local.bucket_id}"
     origin_path = "${var.cloudfront_origin_path}"
 
     s3_origin_config {
-      origin_access_identity = "${aws_cloudfront_origin_access_identity.identity.cloudfront_access_identity_path}"
+      origin_access_identity = "${var.create_bucket ? join("", aws_cloudfront_origin_access_identity.identity.*.cloudfront_access_identity_path) : var.cloudfront_origin_access_identity_path}"
     }
   }
 
@@ -51,7 +48,7 @@ resource "aws_cloudfront_distribution" "cloudfront" {
   default_cache_behavior {
     allowed_methods        = "${var.cloudfront_default_cache_allowed_methods}"
     cached_methods         = "${var.cloudfront_default_cache_cached_methods}"
-    target_origin_id       = "${aws_s3_bucket.bucket.id}"
+    target_origin_id       = "${var.create_bucket ? join("", aws_s3_bucket.bucket.*.id) : local.bucket_id}"
     compress               = "${var.cloudfront_default_cache_compress}"
     default_ttl            = "${var.cloudfront_default_cache_default_ttl}"
     max_ttl                = "${var.cloudfront_default_cache_max_ttl}"

--- a/main.tf
+++ b/main.tf
@@ -29,3 +29,8 @@ data "aws_acm_certificate" "cloudfront" {
   domain   = "${var.cloudfront_acm_cert_domain}"
   statuses = ["ISSUED"]
 }
+
+locals {
+  bucket_id = "${var.bucket_name}"
+  bucket_domain_name = "${var.bucket_name}.s3.amazonaws.com"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,17 @@ variable "bucket_name" {
   type = "string"
 }
 
+variable "create_bucket" {
+  description = "Should this module create and manage this S3 bucket?"
+  default = true
+}
+
+variable "cloudfront_origin_access_identity_path" {
+  description = "CloudFront origin access identity path to use if not creating the S3 bucket"
+  type = "string"
+  default = ""
+}
+
 variable "s3_region" {
   type        = "string"
   description = "AWS region for S3 bucket"

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,12 @@ variable "cloudfront_origin_access_identity_path" {
   default = ""
 }
 
+variable "cloudfront_origin_access_identity_iam_arn" {
+  description = "CloudFront origin access identity iam_arn to use in the S3 bucket policy if not creating the CloudFront origin access identity"
+  type = "string"
+  default = ""
+}
+
 variable "s3_region" {
   type        = "string"
   description = "AWS region for S3 bucket"


### PR DESCRIPTION
This allows to have multiple CloudFront distributions pointing to the
same S3 bucket, such as to different paths.

Note, due to the way the conditional parser works in current version of
Terraform we're using the workaround using join() and the .*. operator,
see https://github.com/hashicorp/hil/issues/50